### PR TITLE
fix: update department model and validation to allow empty strings

### DIFF
--- a/src/models/department.model.js
+++ b/src/models/department.model.js
@@ -15,7 +15,7 @@ const departmentSchema = new mongoose.Schema({
     sparse: true,
     trim: true,
     uppercase: true,
-    minlength: 2,
+    default: '',
     maxlength: 10
   },
   description: {

--- a/src/validation/department.validation.js
+++ b/src/validation/department.validation.js
@@ -99,6 +99,7 @@ const validateDepartmentUpdate = (req, res, next) => {
       .min(2)
       .max(10)
       .optional()
+      .allow('')
       .trim()
       .pattern(/^[A-Z0-9]+$/)
       .messages({
@@ -116,6 +117,7 @@ const validateDepartmentUpdate = (req, res, next) => {
     headOfDepartment: Joi.string()
       .optional()
       .trim()
+      .allow('')
       .messages({
         'string.empty': 'Head of department cannot be empty'
       }),


### PR DESCRIPTION
- Changed the 'name' field in the department model to have a default value of an empty string instead of a minimum length requirement.
- Updated validation for the 'name' and 'headOfDepartment' fields to allow empty strings, improving flexibility in department updates.